### PR TITLE
Update Heroku deployment config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "private": true,
   "scripts": {
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
-    "start": "npm run dev",
+    "start": "node server.js",
     "unit": "jest --config test/unit/jest.conf.js --coverage",
     "e2e": "node test/e2e/runner.js",
     "test": "npm run unit && npm run e2e",
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs",
     "build": "node build/build.js",
-    "postinstall": "yarn build"
+    "heroku-postbuild": "yarn build"
   },
   "dependencies": {
     "autoprefixer": "^7.1.2",


### PR DESCRIPTION
Closes #1. From going through the article, it looked like the only changes that needed to be made were updating `start` and converting `postinstall` to `heroku-postbuild` since all `devDependencies` are already in `dependencies`. I'm also happy to be a guinea pig for a local dev setup/README if that's helpful!