### PR TITLE
Add README, license, local dev fixtures

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 City Bureau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-TODO: document
+# Documenters Assignment Form
+
+Online form created with [Vue.js](https://vuejs.org/) to apply for assignments in [City Bureau's Documenters program](https://www.citybureau.org/documenters/).
+
+## Setup
+
+If you're using [yarn](https://yarnpkg.com), you can install dependencies and run a local development server with:
+
+```bash
+yarn
+yarn run dev
+```
+
+If you're using npm you can run the same commands, substituting `npm` for `yarn`. Once this is run, you should be able to access the application at [http://localhost:8080](http://localhost:8080).
+
+To make local development easier, outside of the production environment all requests to the API are replaced by sample responses. Sample events are in `test/fixtures/events.json`, and assignment request submissions always return a successful response. The live application makes requests to the assignment API (source code at [City-Bureau/assignment-api](https://github.com/City-Bureau/assignment-api)).
+
+## Contributing
+
+The Documenters assignment form is part of the [City Scrapers project of City Bureau Labs](https://github.com/City-Bureau/city-scrapers). Check out that project [README](https://github.com/City-Bureau/city-scrapers/blob/master/README.md) for more information on getting involved.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A Vue.js project",
   "author": "Jim Benton <jim@autonomousmachine.com>",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
@@ -50,6 +51,7 @@
     "eventsource-polyfill": "^0.9.6",
     "express": "^4.16.2",
     "extract-text-webpack-plugin": "^3.0.0",
+    "fetch-intercept": "^2.2.3",
     "file-loader": "^1.1.4",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "html-webpack-plugin": "^2.30.1",

--- a/src/components/AssignmentForm.vue
+++ b/src/components/AssignmentForm.vue
@@ -272,7 +272,7 @@ export default {
     },
 
     domain() {
-      const domain = process.env.NODE_ENV === 'production' ? 'https://documenter-assignments-api.labs.citybureau.org' : 'http://localhost:5000';
+      const domain = process.env.NODE_ENV === 'production' ? 'https://documenter-assignments-api.labs.citybureau.org' : '';
       return domain;
     },
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@
 //
 import 'promise-polyfill/src/polyfill';
 import 'whatwg-fetch';
+import fetchIntercept from 'fetch-intercept';
 
 import Vue from 'vue';
 import App from './App';
@@ -11,6 +12,33 @@ import router from './router';
 Vue.config.productionTip = false;
 
 require('./assets/sass/main.scss');
+
+// Patch any API routes with fixtures if not in production
+if (process.env.NODE_ENV !== 'production') {
+  let apiRoutes = [
+    {
+      method: 'GET',
+      url: 'api/events',
+      response: require('../test/fixtures/events.json')
+    },
+    {
+      method: 'POST',
+      url: 'api/applications',
+      response: { ok: true }
+    }
+  ];
+
+  fetchIntercept.register({
+    response: function (response) {
+      // Return a modified response object if included in patched API routes
+      let route = apiRoutes.find(item => response.url.endsWith(item.url));
+      if (route) {
+        return new Response(JSON.stringify(route.response), { status: 200 });
+      }
+      return response;
+    }
+  });
+}
 
 /* eslint-disable no-new */
 new Vue({

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -1,0 +1,75 @@
+[
+    {
+        "createdTime": "2017-11-21T12:54:25.000Z",
+        "fields": {
+            "agency_name": "Cook County Government",
+            "assignment": [
+                "Audio record meeting"
+            ],
+            "assignment_status": "Open Assignment",
+            "classification": "Committee Meeting",
+            "community_area": "Bucktown",
+            "description": "Committee meeting\u00a0of the Cook County Board of Commissioners.",
+            "id": "CookCounty:FinanceSubcommitteeonWorkers'Compensation2017-12-12T12:30:00-06:00",
+            "location_name": "118 N. Clark St. County Board Room - Rm 569 Chicago , IL  60602",
+            "name": "Cook County: Finance Subcommittee on Workers' Compensation",
+            "start_time": "2017-12-12T18:30:00.000Z",
+            "status": "tentative"
+        },
+        "id": "recdz7JY3N4LmenHE"
+    },
+    {
+        "createdTime": "2017-12-15T04:38:14.000Z",
+        "fields": {
+            "agency_name": "Civilian Office of Police Accountability (COPA)",
+            "assignment": [
+                "Audio record meeting",
+                "Video record meeting"
+            ],
+            "assignment_status": "Open Assignment",
+            "description": "Public meeting for COPA",
+            "location_name": "City Hall \u2014 Room 501A",
+            "start_time": "2017-12-20T14:00:00.000Z"
+        },
+        "id": "recEim7spuopsRHFW"
+    },
+    {
+        "createdTime": "2017-11-30T06:57:12.000Z",
+        "fields": {
+            "agency_name": "Chicago Police Department",
+            "assignment": [
+                "Audio record meeting"
+            ],
+            "assignment_status": "Open Assignment",
+            "classification": "CAPS community event",
+            "community_area": "n/a",
+            "description": "Community Meeting to address crime issues on the beat, develop strategies to solve problems, and dissemination of crime prevention information.",
+            "end_time": "2018-01-18T02:00:00.000Z",
+            "id": "chi_police/201801171900/19/beat_1921_beat_1922_beat_1931_community_meeting",
+            "location_name": "Police Auditorium in Area North, 2452 W. Belmont",
+            "name": "Beat 1921, Beat 1922, & Beat 1931 Community Meeting",
+            "start_time": "2018-01-18T01:00:00.000Z",
+            "status": "confirmed"
+        },
+        "id": "recVJDIK1vYOS1hEp"
+    },
+    {
+        "createdTime": "2017-11-21T18:55:37.000Z",
+        "fields": {
+            "agency_name": "Illinois Department of Public Health",
+            "assignment": [
+                "Live-tweet meeting"
+            ],
+            "assignment_status": "Open Assignment",
+            "classification": "Not classified",
+            "description": "Locations of meeting:\u00a0 Illinois Hospital Association, 1151 E. Warrenville Road, Naperville, IL 60566 and Illinois Hospital Association, 700 South 2nd Street, Springfield, IL 62704\nContact for the meeting @\nIDPH:\u00a0 Evelyn Lyons, 708-327-2556,",
+            "end_time": "2018-03-08T18:00:00.000Z",
+            "id": "il_pubhealth/201803081000/17396/ems_for_children_advisory_council",
+            "location_name": "n/a",
+            "name": "EMS for Children Advisory Council",
+            "start_time": "2018-03-08T16:00:00.000Z",
+            "status": "tentative"
+        },
+        "id": "recDiACARxXroYDJX"
+    }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,6 +2665,10 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+fetch-intercept@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fetch-intercept/-/fetch-intercept-2.2.3.tgz#8cfc03237347be1fecd571006cd8490983a7fed5"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"


### PR DESCRIPTION
Closes #3. Added a README with some basic context that links to to city scrapers repo for more detail so that we don't have to update that in both places. Also added the MIT license (same as in that repo).

This wasn't part of the issue, but I added an interceptor for `fetch` to return fixture data in response to any API requests. I added that because the hardest part for me in getting set up locally was that the app tries to use the `assignment-api` running locally at localhost:5000. We could add to the instructions that people need to be running both at the same time, but this seems easier for onboarding